### PR TITLE
Fix sidebar rss link on /projects page

### DIFF
--- a/src/templates/page-template.js
+++ b/src/templates/page-template.js
@@ -45,6 +45,7 @@ export const pageQuery = graphql`
           github
           linkedin
         }
+        url
       }
     }
     markdownRemark(fields: { slug: { eq: $slug } }) {


### PR DESCRIPTION
If you try to click on the rss link in the sidebar while on `/projects` you would go to `/projects/undefined/rss.xml`. That's undefined because `url` was omitted from the graphql query in `page-template.js`.

It was the simplest possible fix, but it took me a bit to figure out where the props are coming from since I never used gatsby.